### PR TITLE
TStringList::AddObject fix for maintaing sort order when the list is in Sorted mode. 

### DIFF
--- a/src/base/Classes.cpp
+++ b/src/base/Classes.cpp
@@ -800,10 +800,6 @@ intptr_t TStringList::AddObject(UnicodeString S, TObject *AObject)
         break;
       }
     }
-    else
-    {
-      Result = GetCount();
-    }
   }
   InsertItem(Result, S, AObject);
   return Result;


### PR DESCRIPTION
The main objective of this fix is that the NetBox was originated from WinSCP sources where the author extensively used C++ Builder native classes, including TStringList. For the sake of compatibility the authors of NetBox left the WinSCP implementation mostly intact while providing the implementation replacement for the classes (since the standard classes in C++ Builder are close-sourced). But the implementation contained the bug when appending a string to a sorted TStringList actually added a new item at the end of the list instead of inserting it by maintaining the sorting order. 

Author of this request found this inconsistency indirectly when the synchronization list (Mirror, To Local) contained too many items that should not have be in it. A step by step inquiry led to this fix. 

The claim about the sorting issue sounds serious, but there's a reason why it was not discovered previously 

- The NTFS file system due to its performance-oriented nature has a special way to order files in a folder. According to a [blog entry  ](https://devblogs.microsoft.com/oldnewthing/20140304-00/?p=1603) "... maintains directory entries in a B-tree structure.... looks approximately alphabetical for US-English". One can test is with a far "unsorted" order mode at any ntfs-based folder and see that the order is slightly changing when there are several files having the same prefix and the following symbols are an alpha letter for one file and an underscore (_) for another. For example, a folder with two files, _prefixletter.txt_ and _prefix_etter.txt_ does the trick. Possibly it has something to do with uppercase conversion affecting the place where the underscore symbol appear related to upper latin group and lower latin group when sorting ordinarily, but this is just a speculation. If the folder does not contain such groups of files, then, the alpha and unsorted ordering are usually the same so adding to TStringList correctly (by maintaining the sorting order) and incorrectly (by appending at the end) are equivalent. 
- The FAT/FAT32 unsorted order depends on the order of how the files were created. So to see this issue in action, one should create a copy of a remote folder by copying files in reverse alphabetical order and tell NetBox to synchronize. In most cases the list will contain too many files. But due to the fact that FAT32 is very rarely used nowadays, this also wasn't noticed before.
