### PR TITLE
strings vector insert operation fix

### DIFF
--- a/src/base/Classes.cpp
+++ b/src/base/Classes.cpp
@@ -913,7 +913,8 @@ void TStringList::InsertItem(intptr_t Index, UnicodeString S, TObject *AObject)
   }
   else
   {
-    FStrings.insert(FStrings.begin() + Index, S);
+    FStrings.insert(FStrings.begin() + Index, 1, S);
+
     TObjectList::Insert(Index, AObject);
   }
   Changed();


### PR DESCRIPTION
the fix #6 change triggered an access violation exception when working with some local folder and remote directories. 
The method TStringList::InsertItem uses a vector class method 

`  iterator insert(iterator it, const T& val)`

from libs/rdestl/vector.h, that is probably incompatible with the fix in question
But by changing the call into the one providing the number of elements inserted 

`FStrings.insert(FStrings.begin() + Index, 1, S);`

 triggers using another implementation of the insert operation

` void insert(iterator it, size_type n, const T& val)`

the access violation is gone. 