### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [ x64, x86 ]
+
+    env:
+      BUILD_TYPE: Release
+
+    runs-on: windows-2019
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Get version
+        shell: bash
+        run: |
+          export VERSION_MAJOR=$(grep "NETBOX_VERSION_MAJOR" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_MAJOR\s*\([0-9]\+\)/\1/g")
+          export VERSION_MINOR=$(grep "NETBOX_VERSION_MINOR" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_MINOR\s*\([0-9]\+\)/\1/g")
+          export VERSION_PATCH=$(grep "NETBOX_VERSION_PATCH" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_PATCH\s*\([0-9]\+\)/\1/g")
+          export VERSION_BUILD=$(grep "NETBOX_VERSION_BUILD" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_BUILD\s*\([0-9]\+\)/\1/g")
+          echo "VERSION=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH.$VERSION_BUILD.$GITHUB_RUN_NUMBER">> $GITHUB_ENV
+
+      - name: Set the pack file name
+        shell: bash
+        run: |
+          echo "netbox_name=NetBox.${{ matrix.arch }}.${{ env.version }}.7z" >> $GITHUB_ENV
+          echo "netbox_pdb_name=NetBox.${{ matrix.arch }}.${{ env.version }}.pdb.7z" >> $GITHUB_ENV
+
+      - name: Add C++ build tools to PATH
+        uses: ilammy/msvc-dev-cmd@v1.9.0
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Create Build forlder
+        run: cmake -E make_directory build
+
+      - name: Configure CMake
+        shell: bash
+        working-directory: build
+        run: >
+          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE $GITHUB_WORKSPACE/src/NetBox
+
+      - name: Build
+        working-directory: build
+        shell: bash
+        run: cmake --build . --config $BUILD_TYPE
+
+      - name: pack plugin
+        shell: bash
+        run: |
+          cp LICENSE.txt README.md README.RU.md README.PL.md ./Far3_${{ matrix.arch }}/Plugins/NetBox/
+          7z a ${{ env.netbox_name }} ./Far3_${{ matrix.arch }}/Plugins/* -xr!*.pdb
+          7z a ${{ env.netbox_pdb_name }} ./Far3_${{ matrix.arch }}/Plugins/NetBox/NetBox.pdb
+
+      - name: Upload result
+        uses: actions/upload-artifact@v2
+        with:
+          name: result
+          path: ./*.7z
+          retention-days: 1
+
+  create-release:
+    needs: [build]
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Get version
+        shell: bash
+        run: |
+          export VERSION_MAJOR=$(grep "NETBOX_VERSION_MAJOR" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_MAJOR\s*\([0-9]\+\)/\1/g")
+          export VERSION_MINOR=$(grep "NETBOX_VERSION_MINOR" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_MINOR\s*\([0-9]\+\)/\1/g")
+          export VERSION_PATCH=$(grep "NETBOX_VERSION_PATCH" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_PATCH\s*\([0-9]\+\)/\1/g")
+          export VERSION_BUILD=$(grep "NETBOX_VERSION_BUILD" src/NetBox/plugin_version.hpp | sed -e "s/^.* NETBOX_VERSION_BUILD\s*\([0-9]\+\)/\1/g")
+          echo "VERSION=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH.$VERSION_BUILD.$GITHUB_RUN_NUMBER">> $GITHUB_ENV
+
+      - name: Download result
+        uses: actions/download-artifact@v2
+        with:
+          name: result
+
+      - name: Create release
+        shell: bash
+        run: gh release create v${{ env.version }} -t "v${{ env.version }}" -n "NetBox ${{ env.version }}" ./*.7z
+        env:
+          GITHUB_TOKEN: ${{secrets.PACKAGES_GITHUB_TOKEN}}

--- a/src/NetBox/CMakeLists.txt
+++ b/src/NetBox/CMakeLists.txt
@@ -1,5 +1,5 @@
 message(STATUS "CMake version: ${CMAKE_VERSION}")
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 set(OPT_COMPILE_OPENSSL ON CACHE STRING "Default build openSSL")
 set(OPT_USE_UNITY_BUILD ON CACHE STRING "Default use unity build")
@@ -191,7 +191,7 @@ set(NETBOX_DLL_LINK_FLAGS
 )
 #/DELAYLOAD:gdi32.dll
 
-set(NETBOX_DLL_LINK_FLAGS_RELEASE "/OPT:REF")
+set(NETBOX_DLL_LINK_FLAGS_RELEASE "/OPT:REF /MAP /debug /ltcg")
 set(NETBOX_DLL_LINK_FLAGS_DEBUG "/DEBUG")
 
 elseif(CMAKE_COMPILER_IS_MINGW)


### PR DESCRIPTION
Добавлен workflow для github actions.
- запускается на каждый push в master или по ручному действию
- сборка x86 и x64
- на выходе создается релиз с архивами плагина, плюс отдельно pdb файл
- версия архива формируется по версии плагина плюс номер запуска в github actions, т.е. всегда уникальный

для настройки работы необходимо 
1. в профиле пользователя, от имени которого будет создаваться релиз, создать токен (https://github.com/settings/tokens) с правами на группу repo
2. в настройках репозитория создать секрет (https://github.com/FarGroup/Far-NetBox/settings/secrets/actions ) с именем PACKAGES_GITHUB_TOKEN и указать для него значение токена из пункта 1

пример сформированных релизов https://github.com/ctapmex/Far-NetBox/releases

в дальнейшем при сборке FarManager можно будет скачивать всегда самый последний релиз, например так
```
export last_version=$(curl --silent "https://api.github.com/repos/FarGroup/Far-NetBox/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
curl -fsLJO https://github.com/FarGroup/Far-NetBox/releases/download/v${last_version}/NetBox.x64.${last_version}.7z
```