### PR TITLE
Import of files containing cyrillic characters in the session name

### DIFF
--- a/src/core/HierarchicalStorage.cpp
+++ b/src/core/HierarchicalStorage.cpp
@@ -180,8 +180,12 @@ bool THierarchicalStorage::OpenSubKey(UnicodeString ASubKey, bool CanCreate, boo
   }
   else
   {
-    MungedKey = MungeKeyName(Key);
+    MungedKey = MungeStr(Key, GetForceAnsi());
     Result = DoOpenSubKey(MungedKey, CanCreate);
+    if (!Result) {
+        MungedKey = MungeStr(Key, !GetForceAnsi());
+        Result = DoOpenSubKey(MungedKey, CanCreate);
+    }
   }
 
   if (Result)


### PR DESCRIPTION
Импорт файлов содержащие кириллические символы в имени сессии, не корректно обрабатывался.