### PR TITLE
Two-column panel.

### DIFF
--- a/src/core/SessionData.cpp
+++ b/src/core/SessionData.cpp
@@ -300,6 +300,7 @@ void TSessionData::NonPersistant()
 
 #define BASE_PROPERTIES \
   PROPERTY(HostName); \
+  PROPERTY(Description); \
   PROPERTY(PortNumber); \
   PROPERTY(Password); \
   PROPERTY(PublicKeyFile); \
@@ -577,6 +578,7 @@ void TSessionData::DoLoad(THierarchicalStorage *Storage, bool PuttyImport, bool 
 
   SetPortNumber(Storage->ReadInteger("PortNumber", GetPortNumber()));
   SetUserName(Storage->ReadString("UserName", SessionGetUserName()));
+  SetDescription(Storage->ReadString("Description", GetDescription()));
   // must be loaded after UserName, because HostName may be in format user@host
   SetHostName(Storage->ReadString("HostName", GetHostName()));
 
@@ -945,6 +947,7 @@ void TSessionData::DoSave(THierarchicalStorage *Storage,
   Storage->WriteString("Version", ::VersionNumberToStr(::GetCurrentVersionNumber()));
   WRITE_DATA(String, HostName);
   WRITE_DATA(Integer, PortNumber);
+  WRITE_DATA(String, Description);
   WRITE_DATA_EX(Integer, "PingInterval", GetPingInterval() / SecsPerMin, );
   WRITE_DATA_EX(Integer, "PingIntervalSecs", GetPingInterval() % SecsPerMin, );
   Storage->DeleteValue("PingIntervalSec"); // obsolete
@@ -2313,6 +2316,15 @@ void TSessionData::SetHostName(UnicodeString AValue)
     Shred(XPassword);
     Shred(XNewPassword);
   }
+}
+
+void TSessionData::SetDescription(UnicodeString Value)
+{
+    SET_SESSION_PROPERTY(Description);
+}
+UnicodeString TSessionData::GetDescription() const
+{
+    return FDescription;
 }
 
 UnicodeString TSessionData::GetHostNameExpanded() const

--- a/src/core/SessionData.h
+++ b/src/core/SessionData.h
@@ -309,10 +309,12 @@ private:
   TSessionSource FSource;
   bool FSaveOnly;
   UnicodeString FLogicalHostName;
-
+  UnicodeString FDescription;
 public:
   void SetHostName(UnicodeString AValue);
   UnicodeString GetHostNameExpanded() const;
+  void SetDescription(UnicodeString Value);
+  UnicodeString GetDescription() const;
   void SetPortNumber(intptr_t Value);
   void SetUserName(UnicodeString Value);
   UnicodeString GetUserNameExpanded() const;


### PR DESCRIPTION
Добавлен новый сохраняемый параметр для сессии Description.
Добавлен новый двухколоночный режим просмотра сессий по Ctrl+2. Размеры колонок (0,50%), тип колонок (N,Z). Первая колонка как обычно Наименование сессии, а вторая Description.
Изменять Description можно будет в диалоге Наименования сессии, в формате session_name#Discription.
Текст после знака # будет добавлен в Description. Если Description не задавать явно, то будет добавлено значение UserName.
Поддержка добавления/изменения Description будет так же в диалогах Shift+F5 и Shift+F6