### PR TITLE
Local directories with path length between 248 and 259 characters cou…

### DIFF
--- a/src/base/Common.cpp
+++ b/src/base/Common.cpp
@@ -1154,7 +1154,8 @@ UnicodeString ApiPath(UnicodeString APath)
 {
   UnicodeString Result = APath;
 
-  if (IsWin7() || (Result.Length() >= MAX_PATH))
+  // Max path for directories is 12 characters shorter than max path for files
+  if (IsWin7() || (Result.Length() >= MAX_PATH - 12))
   {
 //    if (GetConfiguration() != nullptr)
 //    {


### PR DESCRIPTION
…ld not be created

As explicitly stated by Microsoft [here](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry):

> When using an API to create a directory, the specified path cannot be so long that you cannot append an 8.3 file name (that is, the directory name cannot exceed MAX_PATH minus 12).

Fixed independently, but can be considered as backported from https://github.com/winscp/winscp/commit/205a2a956ffce7a6ef887aa9d554df777af81c4c

**Update**. Detailed explanation of existing problem and proposed solution (in Russian) available [here](https://forum.farmanager.com/viewtopic.php?p=174463#p174463).